### PR TITLE
Fix crashes rendering pipes in 6.0.6

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@ minecraft_version=1.21.1
 # as they do not follow standard versioning conventions.
 minecraft_version_range=[1.21.1, 1.22)
 # The Neo version must agree with the Minecraft version to get a valid artifact
-neo_version=21.1.138
+neo_version=21.1.152
 # The Neo version range can use any version of Neo as bounds
 neo_version_range=[21.1.0,)
 # The loader version range can only use the major version of FML as bounds
@@ -35,9 +35,9 @@ mod_license=All Rights Reserved
 
 mod_version=1.21.1_1.3b
 
-create_version = 6.0.4-55
+create_version = 6.0.6-106
 flywheel_version = 1.0.2
-ponder_version = 1.0.46
+ponder_version = 1.0.59
 registrate_version = MC1.21-1.3.0+62
 jei_version=19.10.0.126
 

--- a/src/main/java/com/rae/crowns/mixin/FluidTransportBehaviourMixin.java
+++ b/src/main/java/com/rae/crowns/mixin/FluidTransportBehaviourMixin.java
@@ -68,7 +68,7 @@ public abstract class FluidTransportBehaviourMixin extends BlockEntityBehaviour 
             boolean sendUpdate = false;
             for (PipeConnection connection : connections) {
                 sendUpdate |= connection.flipFlowsIfPressureReversed();
-                connection.manageSource(world, pos);
+                connection.manageSource(world, pos, blockEntity);
             }
             if (sendUpdate)
                 blockEntity.notifyUpdate();


### PR DESCRIPTION
Fixes #6.
Additionally, fixes an unforeseen error that caused a crash on the same page (older versions of Ponder library do not have the `NeoForgeCatnipServices` class).