### PR TITLE
Fixed swapped item tags

### DIFF
--- a/src/main/resources/data/forge/tags/items/ores/uranium.json
+++ b/src/main/resources/data/forge/tags/items/ores/uranium.json
@@ -1,5 +1,6 @@
 {"replace": false,
   "values": [
-    "crowns:raw_uranium"
+    "crowns:uranium_ore",
+    "crowns:deepslate_uranium_ore"
   ]
 }

--- a/src/main/resources/data/forge/tags/items/raw_materials/uranium.json
+++ b/src/main/resources/data/forge/tags/items/raw_materials/uranium.json
@@ -1,6 +1,5 @@
 {"replace": false,
   "values": [
-    "crowns:uranium_ore",
-    "crowns:deepslate_uranium_ore"
+    "crowns:raw_uranium"
   ]
 }


### PR DESCRIPTION
Minor issue, but it seems like the `forge:raw_materials/uranium` and `forge:ores/uranium` tags were mixed up